### PR TITLE
Align extraction time to time window

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ Files are organized by date and files of the same day are grouped.
 <bucket>:2024-09-04/2024-09-04-12-00.csv
 ```
 
+Data extraction is aligned with function execution time.
+It is possible to align data extracted with extraction time window (for example, export last complete hour) by configuring `/arduino/s3-exporter/{stack-name}/iot/align_with_time_window` property.
+
 ## Deployment via Cloud Formation Template
 
 It is possible to deploy required resources via [cloud formation template](deployment/cloud-formation-template/deployment.yaml)
@@ -74,11 +77,11 @@ These parameters are filled by CFT at stack creation time and can be adjusted la
 | /arduino/s3-exporter/{stack-name}/iot/org-id    | (optional) organization id |
 | /arduino/s3-exporter/{stack-name}/iot/filter/tags    | (optional) tags filtering. Syntax: tag=value,tag2=value2  |
 | /arduino/s3-exporter/{stack-name}/iot/samples-resolution  | (optional) samples aggregation resolution (1/5/15 minutes, 1 hour, raw) |
-| /arduino/s3-exporter/{stack-name}/destination-bucket  | S3 destination bucket |
 | /arduino/s3-exporter/{stack-name}/iot/scheduling | Execution scheduling |
+| /arduino/s3-exporter/{stack-name}/iot/align_with_time_window | Align data extraction with time windows (for example, last complte hour) |
 | /arduino/s3-exporter/{stack-name}/iot/aggregation-statistic | Aggregation statistic |
-
-It is possible to compress (with gzip) files before uploading to S3. To enable compression, add ENABLE_COMPRESSION env variable to lambda configuration (with value true/false).
+| /arduino/s3-exporter/{stack-name}/destination-bucket  | S3 destination bucket |
+| /arduino/s3-exporter/{stack-name}/enable_compression  | Compress CSV files with gzip before uploading to S3 bucket |
 
 ### Tag filtering
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # Arduino AWS S3 CSV exporter
 
 This project provides a way to extract time series samples from Arduino cloud, publishing to a S3 destination bucket.
-Data are extracted at the given resolution via a scheduled Lambda function. Then samples are stored in CSV files and saved to S3.
+Data are extracted at the given resolution via a scheduled Lambda function. Samples are stored in CSV files and saved to S3.
 By default, data extraction is performed every hour (configurable), extracting samples aggregated at 5min resolution (configurable).
-Aggregation is performed as average over aggregation period.
-Non numeric values like strings are sampled at the given resolution.
+Aggregation is performed as average over aggregation period. Non numeric values like strings are sampled at the given resolution.
 
 ## Architecture
 
-S3 exporter is based on a Go lambda function triggered by periodic event from EventBridge.
-Job is configured to extract samples for a 60min time window with the default resolution of 5min.
+S3 exporter is based on a GO Lambda function triggered by periodic event from EventBridge.
+Function is triggered at a fixed rate (by default, 1 hour), starting from the deployment time.
+Rate also define the time extraction window. So, with a 1 hour scheduling, one hour of data are extracted.
 One file is created per execution and contains all samples for selected things. Time series samples are exported at UTC timezone.
 By default, all Arduino things present in the account are exported: it is possible to filter them via [tags](#tag-filtering).
 

--- a/app/exporter/exporter.go
+++ b/app/exporter/exporter.go
@@ -28,7 +28,15 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func StartExporter(ctx context.Context, logger *logrus.Entry, key, secret, orgid string, tagsF *string, resolution, timeWindowMinutes int, destinationS3Bucket string, aggregationStat string, compress bool) error {
+func StartExporter(
+	ctx context.Context,
+	logger *logrus.Entry,
+	key, secret, orgid string,
+	tagsF *string,
+	resolution, timeWindowMinutes int,
+	destinationS3Bucket string,
+	aggregationStat string,
+	compress, enableAlignTimeWindow bool) error {
 
 	// Init client
 	iotcl, err := iot.NewClient(key, secret, orgid)
@@ -36,11 +44,12 @@ func StartExporter(ctx context.Context, logger *logrus.Entry, key, secret, orgid
 		return err
 	}
 
-	if tagsF == nil {
-		logger.Infoln("Things - searching with no filter")
+	if tagsF != nil {
+		logger.Infoln("Filtering things linked to configured account using tags: ", *tagsF)
 	} else {
-		logger.Infoln("Things - searching by tags: ", *tagsF)
+		logger.Infoln("Importing all things linked to configured account")
 	}
+
 	things, err := iotcl.ThingList(ctx, nil, nil, true, utils.ParseTags(tagsF))
 	if err != nil {
 		return err
@@ -60,7 +69,7 @@ func StartExporter(ctx context.Context, logger *logrus.Entry, key, secret, orgid
 		return err
 	}
 
-	if writer, from, err := tsextractorClient.ExportTSToFile(ctx, timeWindowMinutes, thingsMap, resolution, aggregationStat); err != nil {
+	if writer, from, err := tsextractorClient.ExportTSToFile(ctx, timeWindowMinutes, thingsMap, resolution, aggregationStat, enableAlignTimeWindow); err != nil {
 		logger.Error("Error aligning time series samples: ", err)
 		return err
 	} else {

--- a/app/exporter/exporter.go
+++ b/app/exporter/exporter.go
@@ -70,6 +70,10 @@ func StartExporter(
 	}
 
 	if writer, from, err := tsextractorClient.ExportTSToFile(ctx, timeWindowMinutes, thingsMap, resolution, aggregationStat, enableAlignTimeWindow); err != nil {
+		if writer != nil {
+			writer.Close()
+			defer writer.Delete()
+		}
 		logger.Error("Error aligning time series samples: ", err)
 		return err
 	} else {

--- a/business/tsextractor/tsextractor_test.go
+++ b/business/tsextractor/tsextractor_test.go
@@ -16,32 +16,46 @@ import (
 )
 
 func TestTimeAlignment_HourlyTimeWindows(t *testing.T) {
-	// Test the time alignment with hourly time windows
-	from, to := computeTimeAlignment(3600, 60)
+	// Test the time alignment with hourly time windows, not aligned
+	nowTruncated := time.Now().UTC().Truncate(time.Duration(300) * time.Second).Add(-time.Duration(300) * time.Second)
+	fromTuncated := nowTruncated.Add(-time.Hour)
+	from, to := computeTimeAlignment(300, 60, false)
 	assert.Equal(t, int64(3600), to.Unix()-from.Unix())
+	assert.Equal(t, nowTruncated, to)
+	assert.Equal(t, fromTuncated, from)
+}
+
+func TestTimeAlignment_HourlyTimeWindows_aligned(t *testing.T) {
+	// Test the time alignment with hourly time windows, complete last hour
+	nowTruncated := time.Now().UTC().Truncate(time.Hour)
+	fromTuncated := nowTruncated.Add(-time.Hour)
+	from, to := computeTimeAlignment(300, 60, true)
+	assert.Equal(t, int64(3600), to.Unix()-from.Unix())
+	assert.Equal(t, nowTruncated, to)
+	assert.Equal(t, fromTuncated, from)
 }
 
 func TestTimeAlignment_15minTimeWindows(t *testing.T) {
 	// Test the time alignment with hourly time windows
-	from, to := computeTimeAlignment(3600, 15)
+	from, to := computeTimeAlignment(3600, 15, false)
 	assert.Equal(t, int64(900), to.Unix()-from.Unix())
 }
 
 func TestTimeAlignment_15min_HourlyTimeWindows(t *testing.T) {
 	// Test the time alignment with hourly time windows and 15min resolution
-	from, to := computeTimeAlignment(900, 60)
+	from, to := computeTimeAlignment(900, 60, false)
 	assert.Equal(t, int64(3600), to.Unix()-from.Unix())
 }
 
 func TestTimeAlignment_5min_HourlyTimeWindows(t *testing.T) {
 	// Test the time alignment with hourly time windows and 5min resolution
-	from, to := computeTimeAlignment(300, 60)
+	from, to := computeTimeAlignment(300, 60, false)
 	assert.Equal(t, int64(3600), to.Unix()-from.Unix())
 }
 
 func TestTimeAlignment_raw_HourlyTimeWindows(t *testing.T) {
 	// Test the time alignment with hourly time windows and 5min resolution
-	from, to := computeTimeAlignment(-1, 60)
+	from, to := computeTimeAlignment(-1, 60, false)
 	assert.Equal(t, int64(3600), to.Unix()-from.Unix())
 }
 
@@ -91,7 +105,7 @@ func TestExtractionFlow_defaultAggregation(t *testing.T) {
 		PropertiesCount: &propCount,
 	}
 
-	writer, from, err := tsextractorClient.ExportTSToFile(ctx, 60, thingsMap, 300, "AVG")
+	writer, from, err := tsextractorClient.ExportTSToFile(ctx, 60, thingsMap, 300, "AVG", false)
 	assert.NoError(t, err)
 	assert.NotNil(t, writer)
 	assert.NotNil(t, from)

--- a/deployment/cloud-formation-template/deployment.yaml
+++ b/deployment/cloud-formation-template/deployment.yaml
@@ -197,6 +197,22 @@ Resources:
         Ref: ResolutionAggregationStatistic
       Tier: Standard
 
+  CompressionParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub /arduino/s3-exporter/${AWS::StackName}/enable_compression
+      Type: String
+      Value: "false"
+      Tier: Standard
+
+  AlignExtractionParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub /arduino/s3-exporter/${AWS::StackName}/iot/align_with_time_window
+      Type: String
+      Value: "false"
+      Tier: Standard
+
   # EventBridge Rule to trigger Lambda every hour
   EventBridgeRule:
     Type: AWS::Events::Rule

--- a/lambda.go
+++ b/lambda.go
@@ -101,7 +101,7 @@ func HandleRequest(ctx context.Context, event *AWSS3ImportTrigger) (*string, err
 		if tagsParam != nil {
 			tags = tagsParam
 		}
-		aggregationStat, _ = paramReader.ReadConfigByStack(AlignWithTimeWindowStack, stackName)
+		aggregationStat, _ = paramReader.ReadConfigByStack(AggregationStatStack, stackName)
 
 		alignTs, _ := paramReader.ReadConfigByStack(AlignWithTimeWindowStack, stackName)
 		if alignTs != nil && *alignTs == "true" {

--- a/lambda.go
+++ b/lambda.go
@@ -33,7 +33,7 @@ type AWSS3ImportTrigger struct {
 const (
 	GlobalArduinoPrefix = "/arduino/s3-importer"
 
-	// Compatibility parameters for backward compatibility
+	// Parameters for backward compatibility
 	IoTApiKey           = GlobalArduinoPrefix + "/iot/api-key"
 	IoTApiSecret        = GlobalArduinoPrefix + "/iot/api-secret"
 	IoTApiOrgId         = GlobalArduinoPrefix + "/iot/org-id"
@@ -190,7 +190,8 @@ func HandleRequest(ctx context.Context, event *AWSS3ImportTrigger) (*string, err
 
 	err = exporter.StartExporter(ctx, logger, *apikey, *apiSecret, organizationId, tags, *resolution, *extractionWindowMinutes, *destinationS3Bucket, *aggregationStat, enabledCompression, enableAlignTimeWindow)
 	if err != nil {
-		return nil, err
+		message := "Error detected during data export"
+		return &message, err
 	}
 
 	message := "Data exported successfully"

--- a/lambda.go
+++ b/lambda.go
@@ -61,8 +61,10 @@ const (
 func HandleRequest(ctx context.Context, event *AWSS3ImportTrigger) (*string, error) {
 
 	logger := logrus.NewEntry(logrus.New())
+
 	stackName := os.Getenv("STACK_NAME")
 	compressFile := os.Getenv("ENABLE_COMPRESSION")
+	alignTimeWindow := os.Getenv("ALIGN_TIME_WINDOW")
 
 	var apikey *string
 	var apiSecret *string
@@ -152,6 +154,10 @@ func HandleRequest(ctx context.Context, event *AWSS3ImportTrigger) (*string, err
 	if compressFile == "true" {
 		enabledCompression = true
 	}
+	enableAlignTimeWindow := false
+	if alignTimeWindow == "true" {
+		enableAlignTimeWindow = true
+	}
 
 	logger.Infoln("------ Running import")
 	if event.Dev || os.Getenv("DEV") == "true" {
@@ -174,10 +180,11 @@ func HandleRequest(ctx context.Context, event *AWSS3ImportTrigger) (*string, err
 		logger.Infoln("resolution:", *resolution, "seconds")
 	}
 	logger.Infoln("aggregation statistic:", *aggregationStat)
-	logger.Infoln("data extraction time windows:", extractionWindowMinutes, "minutes")
+	logger.Infoln("data extraction time window:", *extractionWindowMinutes, "minutes")
 	logger.Infoln("file compression enabled:", enabledCompression)
+	logger.Infoln("align time window:", enableAlignTimeWindow)
 
-	err = exporter.StartExporter(ctx, logger, *apikey, *apiSecret, organizationId, tags, *resolution, *extractionWindowMinutes, *destinationS3Bucket, *aggregationStat, enabledCompression)
+	err = exporter.StartExporter(ctx, logger, *apikey, *apiSecret, organizationId, tags, *resolution, *extractionWindowMinutes, *destinationS3Bucket, *aggregationStat, enabledCompression, enableAlignTimeWindow)
 	if err != nil {
 		return nil, err
 	}

--- a/resources/test/localexecution.go
+++ b/resources/test/localexecution.go
@@ -89,7 +89,7 @@ func HandleRequest(ctx context.Context, dev bool) (*string, error) {
 		logger.Infoln("tags:", *tags)
 	}
 
-	err = exporter.StartExporter(ctx, logger, *apikey, *apiSecret, organizationId, tags, *resolution, TimeExtractionWindowMinutes, *destinationS3Bucket, "MAX", true)
+	err = exporter.StartExporter(ctx, logger, *apikey, *apiSecret, organizationId, tags, *resolution, TimeExtractionWindowMinutes, *destinationS3Bucket, "MAX", true, true)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### Motivation
Align time extraction windows to scheduling (if required).
This allow the extraction of a complete last period (like complete last hour)

### Reviewer checklist

* [ ] PR address a single concern.
* [ ] PR title and description are properly filled.
* [ ] Changes will be merged in `main`.
* [ ] Changes are covered by tests.
* [ ] Logging is meaningful in case of troubleshooting.
* [ ] History is clean, commit messages are meaningful and are well formatted.
